### PR TITLE
adding GHA workflow + env file

### DIFF
--- a/.github/workflows/run_python_script.yml
+++ b/.github/workflows/run_python_script.yml
@@ -1,0 +1,42 @@
+name: Generate README workflow
+
+on:
+  push:
+     branches:
+       - main
+     paths:
+       - 'generate_readme.py'
+       - 'data/cefi_list.json'
+#  schedule:
+#    - cron: "0 12 5 * *"
+
+jobs:
+  generate_readme:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          activate-conda: false
+          conda-channels: conda-forge
+
+      - name: Build environment
+        shell: bash -l {0}
+        run: |
+          conda env create -f environment.yml
+      - name: Generate the README from JSON source
+        run: |
+          source activate cefi-info-hub
+          python generate_readme.py
+      - name: Commit and push if it changed
+        run: |
+          git config user.name "Automated"
+          git config user.email "actions@users.noreply.github.com"
+          git add -A
+          timestamp=$(date -u)
+          git commit -m "Latest data: ${timestamp}" || exit 0
+          git push

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: cefi-info-hub
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+    - mdutils


### PR DESCRIPTION
This action will only run when changes are pushed to the following files on the `main` branch.
* `generate_readme.py`
* `data/cefi_list.json`

Since the last step in the Action is to `git commit` and `git push` you will have to allow GH Actions workflows R+W permissions (see screenshot below).

![image](https://user-images.githubusercontent.com/8480023/226925549-7b70a70a-25c3-427b-8ca1-ce707a314b52.png)

Lastly, merging in this PR will not make the action run. You will have to make an edit to either file above, after the PR is merged, to get it to run. 

Let me know if you have any questions about what I've done. There is a lot of capability here, so we can explore as needed. 

If you want to see what the GHA does to the repo, take a look at my [`main` branch](https://github.com/MathewBiddle/CEFI-info-hub-list). You can review the successful GHA run [here](https://github.com/MathewBiddle/CEFI-info-hub-list/actions/runs/4490542304/jobs/7897815619).
