### PR TITLE
debugging the GHA deployment of gh-page

### DIFF
--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Create and Deploy Prod HTMl site
+name: Create and Deploy Prod HTML site
 # Includes building automatically when either of the relavent JSON files update on the main branch or on the push of a button
 on:
   workflow_dispatch:
@@ -33,5 +33,5 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: website/deploy # The folder the action should deploy.
-        repository-name: mathewbiddle/CEFI-info-hub-list
+        repository-name: chiaweh2/CEFI-info-hub-list
   #      token: ${{ secrets.API_TOKEN_GITHUB }}

--- a/data/cefi_list.json
+++ b/data/cefi_list.json
@@ -126,7 +126,7 @@
             "18" : "Wind Energy",
             "19" : "Indicators",
             "20" : "Resiliency",
-            "21" : "Algae Bloom"
+            "21" : "Algae Blooms"
         },
         "cplatforms" : {
             "name" : "Observing Platforms",


### PR DESCRIPTION
The merge of PR #32 did not create the gh-page successfully thought the GHA. A fix is attempted by changing the repo name in the yml file in workflow